### PR TITLE
Fix Subscriptions with no user id and Operation Policies

### DIFF
--- a/src/apimtemplate/Core/ArmTemplates/ResourceCreators/ApiResourceCreator.cs
+++ b/src/apimtemplate/Core/ArmTemplates/ResourceCreators/ApiResourceCreator.cs
@@ -129,7 +129,7 @@ namespace Apim.DevOps.Toolkit.Core.ArmTemplates.ResourceCreators
 										new ApiOperationPolicyProperties()
 										{
 											Format = isUrl ? "rawxml-link" : "rawxml",
-											Value = isUrl ? apiDeploymentDefinition.Policy : fileReader.RetrieveFileContentsAsync(apiDeploymentDefinition.Policy).Result
+											Value = isUrl ? operationPolicy : fileReader.RetrieveFileContentsAsync(operationPolicy).Result
 										},
 										new string[] { $"[resourceId('{ResourceType.Api}', parameters('ApimServiceName'), '{apiDeploymentDefinition.Name}')]" });
 

--- a/src/apimtemplate/Core/DeploymentDefinitions/Entities/SubscriptionDeploymentDefinition.cs
+++ b/src/apimtemplate/Core/DeploymentDefinitions/Entities/SubscriptionDeploymentDefinition.cs
@@ -112,10 +112,10 @@ namespace Apim.DevOps.Toolkit.Core.DeploymentDefinitions.Entities
 
 		private string DependentUser()
 		{
-            if (string.IsNullOrWhiteSpace(OwnerId))
-            {
-                return null;
-            }
+			if (string.IsNullOrWhiteSpace(OwnerId))
+			{
+				return null;
+			}
 
 			var regex = new Regex(_userRegexPattern, RegexOptions.IgnoreCase);
 			var match = regex.Match(OwnerId);

--- a/src/apimtemplate/Core/DeploymentDefinitions/Entities/SubscriptionDeploymentDefinition.cs
+++ b/src/apimtemplate/Core/DeploymentDefinitions/Entities/SubscriptionDeploymentDefinition.cs
@@ -112,6 +112,11 @@ namespace Apim.DevOps.Toolkit.Core.DeploymentDefinitions.Entities
 
 		private string DependentUser()
 		{
+            if (string.IsNullOrWhiteSpace(OwnerId))
+            {
+                return null;
+            }
+
 			var regex = new Regex(_userRegexPattern, RegexOptions.IgnoreCase);
 			var match = regex.Match(OwnerId);
 


### PR DESCRIPTION
Bug Fixes:
1. Resolve #13 - Subscription creation did not allow a subscription to be created without an OwnerId/User Id. The user is no longer required for subscriptions per [docs](https://docs.microsoft.com/en-us/powershell/module/az.apimanagement/new-azapimanagementsubscription?view=azps-4.8.0#example-3--create-a-subscription-for-product-scope).
2. Resolve #14 - Operation policies were using xml from the api policy and instead of the operation policy. This causes the api policy to replicated to all defined operation policies.