### PR TITLE
Closes #34. Swagger title update no longer needed as APIM import now respects displayName property

### DIFF
--- a/src/apimtemplate/Core/Infrastructure/OpenAPISpecReader.cs
+++ b/src/apimtemplate/Core/Infrastructure/OpenAPISpecReader.cs
@@ -53,13 +53,9 @@ namespace Apim.DevOps.Toolkit.Core.Infrastructure
 			throw new Exception("Unsupported OpenApi format. The OpenApi document should be provided in json format. Version 2 and 3 of OpenApi are supported");
 		}
 
-		public async Task<string> GetValue(string apiTitle)
+		public async Task<string> GetValue()
 		{
-			var swaggerJson = await GetContent();
-
-			var swagger = JsonConvert.DeserializeObject<dynamic>(swaggerJson);
-			swagger.info.title = apiTitle;
-			return JsonConvert.SerializeObject(swagger);
+			return _openApiFilePath.IsUri(out _) ? _openApiFilePath : await GetContent();
 		}
 
 		private async Task<string> GetContent()

--- a/src/apimtemplate/Core/Mapping/ApiMapper.cs
+++ b/src/apimtemplate/Core/Mapping/ApiMapper.cs
@@ -14,7 +14,7 @@ namespace Apim.DevOps.Toolkit.Core.Mapping
 			cfg.CreateMap<ApiDeploymentDefinition, ApiProperties>()
 				.ForMember(dst => dst.Path, opt => opt.MapFrom(src => src.Path.Replace("//", "/").TrimStart(new[] { '/' })))
 				.ForMember(dst => dst.Format, opt => opt.MapFrom(src => new OpenApiSpecReader(src.OpenApiSpec).GetOpenApiFormat().Result))
-				.ForMember(dst => dst.Value, opt => opt.MapFrom(src => new OpenApiSpecReader(src.OpenApiSpec).GetValue(src.DisplayName).Result))
+				.ForMember(dst => dst.Value, opt => opt.MapFrom(src => new OpenApiSpecReader(src.OpenApiSpec).GetValue().Result))
 				.ForMember(dst => dst.Protocols, opt => opt.MapFrom(src => src.Protocols.GetItems(new[] { "https" })))
 				.ForMember(dst => dst.ApiVersionSetId, opt => opt.MapFrom(src => string.IsNullOrEmpty(src.ApiVersionSetId) ? null : $"[resourceId('{ResourceType.ApiVersionSet}', parameters('ApimServiceName'), '{src.ApiVersionSetId}')]"));
 


### PR DESCRIPTION
Fixes #34. Previously we had to download open API spec from URL in order to update the `swagger.info.title` since APIM import would overwrite the `displayName` with the swagger title. This is no longer the case. Hence we shouldn't need to use this workaround.

Please review @mirsaeedi 