### PR TITLE
For #37. Api products/tags remove depends on since products/tags could be managed separately 

### DIFF
--- a/src/apimtemplate/Core/ArmTemplates/ResourceCreators/ApiResourceCreator.cs
+++ b/src/apimtemplate/Core/ArmTemplates/ResourceCreators/ApiResourceCreator.cs
@@ -87,8 +87,7 @@ namespace Apim.DevOps.Toolkit.Core.ArmTemplates.ResourceCreators
 									var productName = apiDeploymentDefinition.GetProductName(productDisplayName);
 									var dependencies = new List<string>()
 									{
-								$"[resourceId('{ResourceType.Api}', parameters('ApimServiceName'), '{apiDeploymentDefinition.Name}')]",
-								$"[resourceId('{ResourceType.Product}', parameters('ApimServiceName'), '{productName}')]"
+								$"[resourceId('{ResourceType.Api}', parameters('ApimServiceName'), '{apiDeploymentDefinition.Name}')]"
 									};
 
 									var templateResource = new ArmTemplateResource<ProductApiProperties>(

--- a/src/apimtemplate/Core/DeploymentDefinitions/Entities/ApiDeploymentDefinition.cs
+++ b/src/apimtemplate/Core/DeploymentDefinitions/Entities/ApiDeploymentDefinition.cs
@@ -160,14 +160,18 @@ namespace Apim.DevOps.Toolkit.Core.DeploymentDefinitions.Entities
 
 			if (IsDependentOnProducts())
 			{
-				var dependentProducts = ProductList.Select(product => $"[resourceId('{ResourceType.Product}', parameters('ApimServiceName'), '{GetProductName(product)}')]");
+				var dependentProducts = ProductList
+					.Where(product => Root.Products.Any(p => GetProductName(product) == p.Name))
+					.Select(product => $"[resourceId('{ResourceType.Product}', parameters('ApimServiceName'), '{GetProductName(product)}')]");
 
 				dependencies.AddRange(dependentProducts);
 			}
 
 			if (IsDependentOnTags())
 			{
-				var dependentTags = TagList.Select(tag => $"[resourceId('{ResourceType.Tag}', parameters('ApimServiceName'), '{GetTagName(tag)}')]");
+				var dependentTags = TagList
+					.Where(tag => Root.Tags.Any(t => GetTagName(tag) == t.Name))
+					.Select(tag => $"[resourceId('{ResourceType.Tag}', parameters('ApimServiceName'), '{GetTagName(tag)}')]");
 
 				dependencies.AddRange(dependentTags);
 			}


### PR DESCRIPTION
For #37. Remove products `dependsOn` on products-apis resource since products could be managed separately. This is the behavior in azure-api-management-devops-toolkit, see [here](https://github.com/Azure/azure-api-management-devops-resource-kit/blob/a993488b807459713ee991e36cfbbd5d2f340d42/src/ArmTemplates/Creator/TemplateCreators/ProductAPITemplateCreator.cs#L47)