### PR TITLE
Evaluate isCurrent to false if not specified

### DIFF
--- a/src/apimtemplate/Core/ArmTemplates/ResourceCreators/ApiResourceCreator.cs
+++ b/src/apimtemplate/Core/ArmTemplates/ResourceCreators/ApiResourceCreator.cs
@@ -187,7 +187,7 @@ namespace Apim.DevOps.Toolkit.Core.ArmTemplates.ResourceCreators
 
 			static string GetApiName(ApiDeploymentDefinition apiDeploymentDefinition)
 			{
-				if (int.TryParse(apiDeploymentDefinition.ApiRevision, out var revisionNumber) && revisionNumber >= 1 && apiDeploymentDefinition.IsCurrent == false)
+				if (int.TryParse(apiDeploymentDefinition.ApiRevision, out var revisionNumber) && revisionNumber >= 1 && !(apiDeploymentDefinition.IsCurrent ?? false))
 				{
 					string currentAPIName = apiDeploymentDefinition.Name;
 					return apiDeploymentDefinition.Name += $";rev={revisionNumber}";

--- a/src/apimtemplate/Core/ArmTemplates/ResourceCreators/ApiResourceCreator.cs
+++ b/src/apimtemplate/Core/ArmTemplates/ResourceCreators/ApiResourceCreator.cs
@@ -187,7 +187,7 @@ namespace Apim.DevOps.Toolkit.Core.ArmTemplates.ResourceCreators
 
 			static string GetApiName(ApiDeploymentDefinition apiDeploymentDefinition)
 			{
-				if (int.TryParse(apiDeploymentDefinition.ApiRevision, out var revisionNumber) && revisionNumber >= 1 && !(apiDeploymentDefinition.IsCurrent ?? false))
+				if (int.TryParse(apiDeploymentDefinition.ApiRevision, out var revisionNumber) && revisionNumber >= 1 && apiDeploymentDefinition.IsCurrent != true)
 				{
 					string currentAPIName = apiDeploymentDefinition.Name;
 					return apiDeploymentDefinition.Name += $";rev={revisionNumber}";


### PR DESCRIPTION
@mirsaeedi I think it makes sense to evaluate `isCurrent` to false if not specified. This is the behavior if this property is not specified in the API ARM template. The deployment treats it as false. I see the [DevOps kit have it as non-nullable](https://github.com/Azure/azure-api-management-devops-resource-kit/blob/d6d4f024bd8124268f6ebdc8abb0099c7d0b2a30/src/ArmTemplates/Creator/Models/Parameters/ApiConfig.cs#L34), so they also treat it as false too if not specified.